### PR TITLE
Add CPATH and LIBRARY_PATH environment variable

### DIFF
--- a/ext/rbcuda/extconf.rb
+++ b/ext/rbcuda/extconf.rb
@@ -25,14 +25,14 @@ HEADER_DIRS = [
   INCLUDEDIR,
   '/usr/include',
   nmatrix_header_dir
-]
+] + (ENV['CPATH'] || '').split(':')
 
 LIB_DIRS = [
   '/opt/local/lib',
   '/usr/local/lib',
   LIBDIR,
   '/usr/lib',
-]
+] + (ENV['LIBRARY_PATH'] || '').split(':')
 
 dir_config(extension_name, HEADER_DIRS, LIB_DIRS)
 


### PR DESCRIPTION
I believe that people usually install cuda at `/usr/local/cuda` and configure environment variables as:

```
export CUDA_PATH="/usr/local/cuda"
export CPATH="$CUDA_PATH/include:$CPATH"
export LIBRARY_PATH="$CUDA_PATH/lib64:$CUDA_PATH/lib:$LIBRARY_PATH"
export PATH="$CUDA_PATH/bin:$PATH"
export LD_LIBRARY_PATH="$CUDA_PATH/lib64:$CUDA_PATH/lib:$LD_LIBRARY_PATH"
```

So, I made modified extconf.rb to look `CPATH` and `LIBRARY_PATH` to build.